### PR TITLE
statically link libusb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: conan hal setup
 
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev libudev-dev
+        run: sudo apt-get install -y libudev-dev
 
       # Build picosdk 2.2.0
 

--- a/picotool/conanfile.py
+++ b/picotool/conanfile.py
@@ -70,6 +70,9 @@ class Picotool(ConanFile):
                 base_path=EXPORT_SOURCE / "picotool",
             )
 
+    def configure(self):
+        self.options["libusb/*"].shared = False
+
     def generate(self):
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
Dynamic linking requires consumers install the dependent packages, which requires uploading to the remote. This is annoying, so let's not do that.