### PR TITLE
Remove build tool dependencies from the ID

### DIFF
--- a/pico-sdk/conanfile.py
+++ b/pico-sdk/conanfile.py
@@ -58,4 +58,4 @@ class PicoSDK(ConanFile):
         self.cpp_info.libdirs = []  # nothing is being built
 
     def package_id(self):
-        self.info.settings.clear()
+        self.info.clear()

--- a/picotool/conanfile.py
+++ b/picotool/conanfile.py
@@ -92,4 +92,4 @@ class Picotool(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.build_type
-        del self.info.requires
+        self.info.requires.clear()

--- a/picotool/conanfile.py
+++ b/picotool/conanfile.py
@@ -92,3 +92,4 @@ class Picotool(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.build_type
+        del self.info.requires

--- a/pioasm/conanfile.py
+++ b/pioasm/conanfile.py
@@ -76,3 +76,4 @@ class PioASM(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.build_type
+        del self.info.requires

--- a/pioasm/conanfile.py
+++ b/pioasm/conanfile.py
@@ -76,4 +76,4 @@ class PioASM(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.build_type
-        del self.info.requires
+        self.info.requires.clear()


### PR DESCRIPTION
Conan by default uses the dependencies in the package id. Since these are build tools, it doesn't really matter what the dependencies are as long as they are statically linked.